### PR TITLE
draft of a makefile that uses more cores for htslib and also autoconf…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,4 @@ include/htslib/test/test_kstring
 include/htslib/test/test_realn
 include/htslib/test/test_str2int
 include/htslib/test/test_view
-
+include/htslib_configured

--- a/README.md
+++ b/README.md
@@ -36,8 +36,16 @@ To build psass, follow these instructions:
 git clone https://github.com/RomainFeron/PSASS.git
 # Navigate to the PSASS directory
 cd psass
-# Build PSASS
-make
+# Build PSASS; HTSLIB_CORES defines number of cores used for compilation of htslib library (1 if not defined)
+make all HTSLIB_CORES=4
+```
+
+If your system does not have well configured autotools to configure compilation of `htslib`, you can try using the default configuration
+
+```bash
+make clean-htslib
+touch include/htslib_configured
+make HTSLIB_CORES=4
 ```
 
 ## Usage: *psass*
@@ -263,4 +271,3 @@ OUTPUT_PREFIX             |  `string`  |  Prefix for output files (one output fi
 --max-presence-depth, -e  |   `int`    |  Maximum depth to consider a kmer present in the focal pool      |   99999   |
 --max-absence-depth, -a   |   `int`    |  Maximum depth to consider a kmer absent in the other pool       |       0   |
 --help                    |            |  Display help message                                            |           |
-


### PR DESCRIPTION
draft of a makefile that uses more cores for htslib and also autoconfigures before compilation, but it does no work on my computer (when I use configure that build fails, when I use the default one everything works, not sure why.).

Basically I introduced:
 1. evironmental variable defining number of cores of htslib
 2. a dummy files that holds the configuration timestamp

Repeated executions of make won't reconfigure unless the dummy file disappears. It would be possible to condition it also so something within the library (so it gets reconfigured when you change the library), but that seemed a bit cumbersome. You can always just do `make -B` to force everything.

You also had a small mistake in the binary recepies - you need to specify the target with the prefix, otherwise it will not be able to check the timestamp and try to relink everytime you execute make. That's fixed now.

Good luck



